### PR TITLE
Tell ebean server config to make setDdlGenerate and setDdlRun true, s…

### DIFF
--- a/src/main/java/org/example/sboot/service/EbeanFactoryBean.java
+++ b/src/main/java/org/example/sboot/service/EbeanFactoryBean.java
@@ -33,7 +33,9 @@ public class EbeanFactoryBean implements FactoryBean<EbeanServer> {
 
     config.loadFromProperties();
     config.loadTestProperties();
-
+    config.setDdlGenerate(true);
+    config.setDdlRun(true);
+    
     return EbeanServerFactory.create(config);
   }
 


### PR DESCRIPTION
When firstly running this project, there is exception:

`Query threw SQLException:Table \"EXA_CONTENT\" not found; SQL statement:\nselect t0.id, t0.name, t0.version, t0.when_created, t0.when_modified, t0.who_created, t0.who_modified from exa_content t0 [42102-196] Bind values:[null] Query was:select t0.id, t0.name, t0.version, t0.when_created, t0.when_modified, t0.who_created, t0.who_modified from exa_content t0`

I'am pretty sure that the table from Entity was not generated yet, so we have to activate it by setting ServerConfig object at file EbeabFactoryBean to add this two method `config.setDdlGenerate(true);` and `config.setDdlRun(true);`

This pull request fix that issue, so developer can make git clone and `mvn spring-boot:run` without that issue.